### PR TITLE
Load icons from theme

### DIFF
--- a/media/styles.css
+++ b/media/styles.css
@@ -88,6 +88,7 @@ body {
 }
 
 .file-icon {
+    font-size: 16px;
     flex-shrink: 0;
     width: 16px;
     height: 16px;

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+
 export class FileService {
     async getFileContent(filePath: string): Promise<string> {
         const uri = vscode.Uri.file(filePath);

--- a/src/services/IconThemeService.ts
+++ b/src/services/IconThemeService.ts
@@ -1,0 +1,182 @@
+
+import path from 'path';
+import fs from 'fs';
+import * as vscode from 'vscode';
+import { Font, ResolvedIconDefinition } from '../types';
+
+
+export class IconThemeService {
+  private extensionToLangId: Map<string, string> = new Map();
+  private langIdToExtensions: Map<string, string[]> = new Map();
+
+  private iconThemeId: string | undefined;
+
+  private iconThemeExtension: vscode.Extension<any> | undefined;
+  private iconTheme: any | undefined;
+  private iconThemePath: string | undefined;
+
+  private themeJson: any = {};
+
+  constructor() {
+    const config = vscode.workspace.getConfiguration("workbench")
+    this.iconThemeId = config.get<string>("iconTheme")
+
+    for (const ext of vscode.extensions.all) {
+      const contributes = ext.packageJSON.contributes
+      if (contributes?.iconThemes) {
+        const theme = contributes.iconThemes.find((t: any) => t.id === this.iconThemeId)
+        if (theme) {
+          this.iconThemeExtension = ext
+          this.iconTheme = theme
+        }
+      }
+
+      const langs = ext.packageJSON?.contributes?.languages || []
+      for (const lang of langs) {
+        const extensions = lang.extensions || []
+        const langId = lang.id
+        if (!this.langIdToExtensions.has(langId)) {
+          this.langIdToExtensions.set(langId, [])
+        }
+        for (const fileExt of extensions) {
+          const cleanExt = fileExt.startsWith(".") ? fileExt.slice(1) : fileExt
+          this.extensionToLangId.set(cleanExt, langId)
+          this.langIdToExtensions.get(langId)!.push(cleanExt)
+        }
+      }
+
+      if (this.iconThemeExtension && this.iconTheme) {
+        this.iconThemePath = path.resolve(this.iconThemeExtension.extensionPath, this.iconTheme.path)
+        this.themeJson = JSON.parse(fs.readFileSync(this.iconThemePath, "utf-8"))
+      }
+    }
+  }
+
+  getIconThemeExtension(): vscode.Extension<any> | undefined {
+    return this.iconThemeExtension;
+  }
+
+  getIconFonts(): Font[] {
+    const fonts: Font[] = []
+
+    console.log(this.themeJson)
+    for (const font of this.themeJson.fonts || []) {
+      const fontId = font.id
+      const fontSrcs = font.src || []
+      if (fontSrcs.length === 0) {
+        continue;
+      }
+      const src = fontSrcs[0]
+      const themeDir = this.iconThemePath ? path.dirname(this.iconThemePath) : ""
+      const absPath = path.isAbsolute(src.path) ? src.path : path.resolve(themeDir, src.path)
+      fonts.push({
+        fontId,
+        fontFormat: src.format || "truetype",
+        fontUri: vscode.Uri.file(absPath),
+        fontWeight: font.fontWeight,
+        fontStyle: font.fontStyle,
+        fontSize: font.fontSize,
+      })
+
+    }
+    return fonts
+  }
+
+  getIconForPath(filePath: string): ResolvedIconDefinition | null {
+    const fileName = path.basename(filePath)
+    // Naive check
+    const isFile = fileName.includes('.')
+    if (isFile) {
+      return this.getIconForFileName(fileName)
+    } else {
+      return this.getIconForFolder(fileName)
+    }
+  }
+
+  private getIconForFolder(folderName: string): ResolvedIconDefinition | null {
+    const iconName = this.themeJson.folderNames?.[folderName] || this.themeJson.folder || "_folder"
+
+    const def = this.themeJson.iconDefinitions?.[iconName]
+    return this.resolveIconDefinition(def);
+  }
+
+  private getIconForFileName(fileName: string): ResolvedIconDefinition | null {
+    // Look up icon name from fileName
+    const fileExtension = path.extname(fileName).replace(/^\./, "")
+    let iconName: string | undefined
+
+    // Filename > Extension > Language > Default
+    if (fileName.includes(".")) {
+      // Looks like a full filename, search json for a match
+      iconName = this.themeJson.fileNames?.[fileName]
+    }
+    if (!iconName) {
+      // Search for a full file names like "index.ts"
+      iconName = this.themeJson.fileExtensions?.[fileName]
+      if (!iconName) {
+        // Search for a lang file extension for strings like "ts"
+        iconName = this.themeJson.fileExtensions?.[fileExtension]
+      }
+    }
+    if (!iconName) {
+      // Search for a lang id from a map
+      const langId = this.extensionToLangId.get(fileName) || this.extensionToLangId.get(fileExtension)
+      if (langId) {
+        iconName = this.themeJson.languageIds?.[langId]
+      }
+    }
+
+    if (!iconName) {
+      // Default file icon in case none been found
+      iconName = this.themeJson.file || "_file"
+    }
+
+    // Get icon definition
+    const def = this.themeJson.iconDefinitions?.[iconName!]
+
+    return this.resolveIconDefinition(def);
+  }
+
+  private resolveIconDefinition(iconDefinition: any): ResolvedIconDefinition | null {
+    if (!iconDefinition) {
+      return null;
+    }
+
+    const isFont = !!iconDefinition.fontCharacter
+    if (isFont) {
+      return {
+        fontCharacter: iconDefinition.fontCharacter,
+        fontColor: iconDefinition.fontColor,
+        fontSize: iconDefinition.fontSize,
+        fontId: iconDefinition.fontId || this.themeJson.fonts?.[0]?.id,
+      }
+    }
+
+    const iconPath = iconDefinition.iconPath
+    if (!iconPath) {
+      return null;
+    }
+
+    let svgRelPath = ""
+    if (typeof iconPath === "string") {
+      svgRelPath = iconPath
+    } else if (typeof iconPath === "object") {
+      // Icon themes rarely have icons specific to theme kind, but they still may, so it’s safer to check for that
+      const themeKind = vscode.window.activeColorTheme.kind
+      if (themeKind === vscode.ColorThemeKind.HighContrast) {
+        svgRelPath = iconPath.highContrast || iconPath.dark || iconPath.light || ""
+      } else if (themeKind === vscode.ColorThemeKind.HighContrastLight) {
+        svgRelPath = iconPath.highContrastLight || iconPath.light || iconPath.dark || ""
+      } else if (themeKind === vscode.ColorThemeKind.Light) {
+        svgRelPath = iconPath.light || iconPath.dark || ""
+      } else {
+        svgRelPath = iconPath.dark || iconPath.light || ""
+      }
+    }
+
+    // For svgs resolve them to webview URI from an abs path
+    const themeDir = this.iconThemePath ? path.dirname(this.iconThemePath) : ""
+    const absPath = path.isAbsolute(svgRelPath) ? svgRelPath : path.resolve(themeDir, svgRelPath)
+    return { svgPath: absPath }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { type Uri } from 'vscode';
+
 export interface SearchMatch {
     filePath: string;
     relativePath: string;
@@ -7,10 +9,31 @@ export interface SearchMatch {
     preview: string;
 }
 
+export interface Font {
+    fontId: string;
+    fontFormat: string;
+    fontUri: Uri;
+    fontWeight?: string;
+    fontStyle?: string;
+    fontSize?: string;
+}
+
+export type ResolvedIconDefinition = {
+    fontCharacter?: never
+    svgPath: string;
+} | {
+    svgPath?: never;
+    fontCharacter: string;
+    fontColor?: string;
+    fontSize?: string;
+    fontId?: string;
+};
+
 export interface FileSearchResult {
     filePath: string;
     relativePath: string;
     matches: SearchMatch[];
+    icon?: ResolvedIconDefinition;
 }
 
 export type WebviewMessage = {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -1,12 +1,33 @@
 import { Uri } from 'vscode';
 import { getNonce } from '../util';
+import { Font } from '../types';
 
 type WebviewContentOptions = {
     scriptUri: Uri,
     styleUri: Uri,
     wordWrap?: string;
+    fonts?: Font[];
 }
 
+function generateFontFaceStyles(fonts?: Font[]): string {
+    if (!fonts || fonts.length === 0) {
+        return '';
+    }
+
+    return fonts.map((font) => `
+        @font-face {
+            font-family: '${font.fontId}';
+            src: url('${font.fontUri}') format('${font.fontFormat}');
+            font-weight: ${font.fontWeight || 'normal'};
+            font-style: ${font.fontStyle || 'normal'};
+            font-size: ${font.fontSize || '16px'};
+        }
+
+        .icon-font-${font.fontId} {
+            font-family: '${font.fontId}';
+        }
+    `).join('\n');
+}
 
 export function getWebviewContent(options: WebviewContentOptions): string {
     return `<!DOCTYPE html>
@@ -15,6 +36,11 @@ export function getWebviewContent(options: WebviewContentOptions): string {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Search</title>
+
+    <style>
+        ${generateFontFaceStyles(options.fonts)}
+    </style>
+
     <link rel="stylesheet" href="${options.styleUri}">
 </head>
 <body class="${options.wordWrap === 'off' ? '' : 'wrap-lines'}">


### PR DESCRIPTION
This PR automatically loads icons from the users theme instead of constructing custom icons. I think this establishes some more visual consistency and gives more clarity when looking for specific results.

I'm pretty sure this does work in basically all cases, I covered svg and font based icon themes which both seem to work. It is a bit difficult to test all edge cases though.

Also, the font tracking is a bit inefficient right now as there is no cache for duplicate lookups and the icon data is attached to every result individually, but I think that part is fine in it's first version.

 @zigcBenx let me know what you think.