### PR TITLE
fix: activate contributed commands explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand:custom-search.openSearch",
+    "onCommand:custom-search.openNewSearchTab",
+    "onCommand:custom-search.searchInFolder"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [


### PR DESCRIPTION
## What this PR does

Adds explicit VS Code activation events for each contributed Storm Search command.

## Why

Closes #39. The reported warning says `command 'custom-search.searchInFolder' not found` after pressing the contributed keybinding on a fresh install. The command is contributed in `package.json` and registered in `src/extension.ts`, but the extension manifest currently has an empty `activationEvents` array. Explicit `onCommand` activation events make VS Code activate the extension before running the contributed commands.

## Changes

- Adds `onCommand:custom-search.openSearch`.
- Adds `onCommand:custom-search.openNewSearchTab`.
- Adds `onCommand:custom-search.searchInFolder`.

## Duplicate check

- Checked issue #39 comments before implementation; the only comment was the maintainer asking for the VS Code version.
- `gh pr list --repo zigcBenx/storm-search --state all --search "39 Command not found"` returned no PRs.
- `gh pr list --repo zigcBenx/storm-search --state all --search "command not found activationEvents searchInFolder"` returned no PRs.

## Testing

```bash
npm ci
npm run compile
git diff --check
```

`npm run lint` is currently blocked by the repository not having an ESLint configuration file, so ESLint exits before linting source files. I did not add unrelated lint configuration in this PR.