### PR TITLE
Remember file mask between search panels

### DIFF
--- a/src/WebviewManager.ts
+++ b/src/WebviewManager.ts
@@ -7,6 +7,8 @@ import { getWebviewContent } from './webview/webviewContent';
 import { IconThemeService } from './services/IconThemeService';
 
 export class WebviewManager {
+    private static readonly fileMaskStorageKey = 'stormSearch.fileMask';
+
     private panels: Map<string, vscode.WebviewPanel> = new Map();
     private panelSearches: Map<string, string> = new Map();
 
@@ -122,6 +124,7 @@ export class WebviewManager {
             scriptUri,
             styleUri,
             wordWrap,
+            fileMask: this.getStoredFileMask(),
             fonts: iconFonts.map((font) => ({
                 ...font,
                 fontUri: panel.webview.asWebviewUri(font.fontUri)
@@ -171,7 +174,19 @@ export class WebviewManager {
             case 'pickDirectory':
                 await this.handlePickDirectory(panel);
                 break;
+
+            case 'updateFileMask':
+                await this.handleUpdateFileMask(message.fileMask);
+                break;
         }
+    }
+
+    private getStoredFileMask(): string {
+        return this.context.workspaceState.get<string>(WebviewManager.fileMaskStorageKey, '');
+    }
+
+    private async handleUpdateFileMask(fileMask: string): Promise<void> {
+        await this.context.workspaceState.update(WebviewManager.fileMaskStorageKey, fileMask);
     }
 
     private async handleSearch(panelId: string, panel: vscode.WebviewPanel, query: string, includePattern?: string, excludePattern?: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,9 @@ export type WebviewMessage = {
     command: 'close';
 } | {
     command: 'pickDirectory';
+} | {
+    command: 'updateFileMask';
+    fileMask: string;
 }
 
 export interface SearchOptions {

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -31,7 +31,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
     let allFiles: Set<string> = new Set();
     let currentScope: string = 'project';
     let scopePath: string = '';
-    let fileMask: string = '';
+    let fileMask: string = fileMaskInput.value.trim();
 
     let selectedMatchIndex = -1;
     let currentQuery = '';
@@ -178,8 +178,17 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
 
     fileMaskInput.addEventListener('input', () => {
         fileMask = fileMaskInput.value.trim();
+        postMessage({
+            command: 'updateFileMask',
+            fileMask
+        });
         performSearch();
     });
+
+    if (fileMask) {
+        filterContainer.style.display = 'flex';
+        filterToggleButton.classList.add('active');
+    }
 
     // Scope selector logic
     scopeButtons.forEach(button => {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -7,6 +7,7 @@ type WebviewContentOptions = {
     styleUri: Uri,
     wordWrap?: string;
     fonts?: Font[];
+    fileMask?: string;
 }
 
 function generateFontFaceStyles(fonts?: Font[]): string {
@@ -29,7 +30,17 @@ function generateFontFaceStyles(fonts?: Font[]): string {
     `).join('\n');
 }
 
+function escapeAttribute(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
 export function getWebviewContent(options: WebviewContentOptions): string {
+    const fileMask = options.fileMask || '';
+
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -66,6 +77,7 @@ export function getWebviewContent(options: WebviewContentOptions): string {
                 class="file-mask-input"
                 id="fileMaskInput"
                 placeholder="*.ts, *.js (comma-separated)"
+                value="${escapeAttribute(fileMask)}"
             />
         </div>
         <div class="scope-container">


### PR DESCRIPTION
Fixes #37.

This persists the File mask field between Storm Search panels.

Changes:
- stores file mask updates in VS Code `workspaceState`
- injects the saved file mask into newly created webview panels
- initializes the webview search filter state from the restored input value
- automatically opens the filter row when a saved file mask exists
- escapes the saved value before putting it into the input attribute

Verification:
```powershell
npm ci
npm run compile
```

`npm run compile` passes.

I also ran `npm run lint`, but the repository currently has no ESLint config file, so ESLint exits before linting source files:

```text
ESLint couldn't find a configuration file.
```