### PR TITLE
Add shortcut to jump to next result file

### DIFF
--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -412,6 +412,24 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
     // @ts-ignore
     window.selectMatchById = selectMatchById;
 
+    function selectFirstMatchInNextFile() {
+        if (allMatches.length === 0) return;
+
+        if (selectedMatchIndex < 0) {
+            selectMatchById(0);
+            return;
+        }
+
+        const currentFile = allMatches[selectedMatchIndex].relativePath;
+
+        for (let i = selectedMatchIndex + 1; i < allMatches.length; i++) {
+            if (allMatches[i].relativePath !== currentFile) {
+                selectMatchById(allMatches[i].matchId);
+                return;
+            }
+        }
+    }
+
     function openMatchById(matchId: number, event?: MouseEvent) {
         if (matchId < 0 || matchId >= allMatches.length) return;
 
@@ -670,7 +688,9 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         // Arrow key navigation - works even when in search input
         if (e.key === 'ArrowDown' && !isInOtherInput) {
             e.preventDefault();
-            if (selectedMatchIndex < allMatches.length - 1) {
+            if (e.ctrlKey || e.metaKey) {
+                selectFirstMatchInNextFile();
+            } else if (selectedMatchIndex < allMatches.length - 1) {
                 selectMatchById(selectedMatchIndex + 1);
             }
         } else if (e.key === 'ArrowUp' && !isInOtherInput) {


### PR DESCRIPTION
Fixes #34.

This adds the requested keyboard shortcut for moving from the current search result to the first result in the next file group.

Behavior:
- plain `ArrowDown` still moves to the next match as before
- `Ctrl+ArrowDown` jumps to the first match whose file differs from the currently selected match
- `Cmd+ArrowDown` is also supported for macOS keyboards
- if no match is selected yet, the shortcut selects the first match

Verification:
```powershell
npm run compile
```

`npm run compile` passes.

I also ran `npm run lint`, but the repository currently has no ESLint config file, so ESLint exits before checking source files:

```text
ESLint couldn't find a configuration file.
```