### PR TITLE
Add regex option to search

### DIFF
--- a/media/styles.css
+++ b/media/styles.css
@@ -46,7 +46,8 @@ body {
     color: var(--vscode-input-placeholderForeground);
 }
 
-.filter-toggle-button {
+.filter-toggle-button,
+.regex-toggle-button {
     background: var(--vscode-button-secondaryBackground);
     color: var(--vscode-button-secondaryForeground);
     border: 1px solid var(--vscode-input-border);
@@ -59,11 +60,20 @@ body {
     transition: background 0.1s;
 }
 
-.filter-toggle-button:hover {
+.regex-toggle-button {
+    min-width: 32px;
+    font-weight: 600;
+    font-size: 12px;
+    font-family: var(--vscode-editor-font-family, var(--vscode-font-family));
+}
+
+.filter-toggle-button:hover,
+.regex-toggle-button:hover {
     background: var(--vscode-button-secondaryHoverBackground);
 }
 
-.filter-toggle-button.active {
+.filter-toggle-button.active,
+.regex-toggle-button.active {
     background: var(--vscode-button-background);
     color: var(--vscode-button-foreground);
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
+    "test:search-pattern": "npm run compile && node tests/searchPattern.test.js",
     "lint": "eslint src --ext ts"
   },
   "devDependencies": {

--- a/src/WebviewManager.ts
+++ b/src/WebviewManager.ts
@@ -152,7 +152,7 @@ export class WebviewManager {
 
             case 'search':
                 if (message.text) {
-                    await this.handleSearch(panelId, panel, message.text, message.includePattern, message.excludePattern);
+                    await this.handleSearch(panelId, panel, message.text, message.includePattern, message.excludePattern, message.isRegex);
                 }
                 break;
 
@@ -174,22 +174,23 @@ export class WebviewManager {
         }
     }
 
-    private async handleSearch(panelId: string, panel: vscode.WebviewPanel, query: string, includePattern?: string, excludePattern?: string): Promise<void> {
+    private async handleSearch(panelId: string, panel: vscode.WebviewPanel, query: string, includePattern?: string, excludePattern?: string, isRegex: boolean = false): Promise<void> {
         try {
-            this.panelSearches.set(panelId, query);
+            const searchId = `${isRegex ? 'regex' : 'literal'}:${query}`;
+            this.panelSearches.set(panelId, searchId);
 
             const searchableFiles = await this.searchService.getSearchableFiles();
             const searchOptions = this.searchService.getSearchOptions();
             let resultCount = 0;
 
             for (let i = 0; i < searchableFiles.length; i += searchOptions.batchSize) {
-                if (this.panelSearches.get(panelId) !== query) {
+                if (this.panelSearches.get(panelId) !== searchId) {
                     // A new search has been initiated in this panel, abort current search
                     return;
                 }
 
                 const batch = searchableFiles.slice(i, i + searchOptions.batchSize);
-                const results = await this.searchService.search(batch, query, includePattern, excludePattern);
+                const results = await this.searchService.search(batch, query, includePattern, excludePattern, isRegex);
                 if (results.length === 0) {
                     continue;
                 }

--- a/src/searchPattern.ts
+++ b/src/searchPattern.ts
@@ -1,7 +1,8 @@
 import { escapeRegExp } from './util';
 
 export type SearchPattern = {
-    expression: RegExp;
+    source: string;
+    flags: string;
 };
 
 export type PatternMatch = {
@@ -15,8 +16,13 @@ export function createSearchPattern(query: string, isRegex: boolean): SearchPatt
     }
 
     try {
+        const source = isRegex ? query : escapeRegExp(query);
+        const flags = 'gi';
+        new RegExp(source, flags);
+
         return {
-            expression: new RegExp(isRegex ? query : escapeRegExp(query), 'gi')
+            source,
+            flags
         };
     } catch {
         return null;
@@ -25,12 +31,12 @@ export function createSearchPattern(query: string, isRegex: boolean): SearchPatt
 
 export function findPatternMatches(text: string, pattern: SearchPattern): PatternMatch[] {
     const matches: PatternMatch[] = [];
-    pattern.expression.lastIndex = 0;
+    const expression = new RegExp(pattern.source, pattern.flags);
 
     let match: RegExpExecArray | null;
-    while ((match = pattern.expression.exec(text)) !== null) {
+    while ((match = expression.exec(text)) !== null) {
         if (match[0].length === 0) {
-            pattern.expression.lastIndex++;
+            expression.lastIndex++;
             continue;
         }
 

--- a/src/searchPattern.ts
+++ b/src/searchPattern.ts
@@ -1,0 +1,44 @@
+import { escapeRegExp } from './util';
+
+export type SearchPattern = {
+    expression: RegExp;
+};
+
+export type PatternMatch = {
+    index: number;
+    length: number;
+};
+
+export function createSearchPattern(query: string, isRegex: boolean): SearchPattern | null {
+    if (!query) {
+        return null;
+    }
+
+    try {
+        return {
+            expression: new RegExp(isRegex ? query : escapeRegExp(query), 'gi')
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function findPatternMatches(text: string, pattern: SearchPattern): PatternMatch[] {
+    const matches: PatternMatch[] = [];
+    pattern.expression.lastIndex = 0;
+
+    let match: RegExpExecArray | null;
+    while ((match = pattern.expression.exec(text)) !== null) {
+        if (match[0].length === 0) {
+            pattern.expression.lastIndex++;
+            continue;
+        }
+
+        matches.push({
+            index: match.index,
+            length: match[0].length
+        });
+    }
+
+    return matches;
+}

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { FileSearchResult, SearchMatch, SearchOptions } from '../types';
 import { BINARY_EXTENSIONS, DEFAULT_SEARCH_OPTIONS } from '../constants';
-import { escapeRegExp, matchGlob } from '../util';
+import { matchGlob } from '../util';
+import { createSearchPattern, findPatternMatches, SearchPattern } from '../searchPattern';
 
 export class SearchService {
     private options: SearchOptions;
@@ -83,9 +84,14 @@ export class SearchService {
         return files;
     }
 
-    async search(files: vscode.Uri[], query: string, includePattern?: string, excludePattern?: string): Promise<FileSearchResult[]> {
+    async search(files: vscode.Uri[], query: string, includePattern?: string, excludePattern?: string, isRegex: boolean = false): Promise<FileSearchResult[]> {
         const fileMatchMap = new Map<string, SearchMatch[]>();
         if (!query) {
+            return [];
+        }
+
+        const searchPattern = createSearchPattern(query, isRegex);
+        if (!searchPattern) {
             return [];
         }
 
@@ -95,8 +101,7 @@ export class SearchService {
             filteredFiles = this.filterFilesByPatterns(files, includePattern, excludePattern);
         }
 
-        const queryLower = query.toLowerCase();
-        await this.searchInBatches(filteredFiles, queryLower, fileMatchMap);
+        await this.searchInBatches(filteredFiles, searchPattern, fileMatchMap);
         return this.convertMapToResults(fileMatchMap);
     }
 
@@ -131,7 +136,7 @@ export class SearchService {
 
     private async searchInBatches(
         files: vscode.Uri[],
-        queryLower: string,
+        searchPattern: SearchPattern,
         fileMatchMap: Map<string, SearchMatch[]>
     ): Promise<void> {
         for (let i = 0; i < files.length; i += this.options.batchSize) {
@@ -140,7 +145,7 @@ export class SearchService {
             }
 
             const batch = files.slice(i, i + this.options.batchSize);
-            const results = await this.searchBatch(batch, queryLower);
+            const results = await this.searchBatch(batch, searchPattern);
 
             for (const result of results) {
                 if (result) {
@@ -152,7 +157,7 @@ export class SearchService {
 
     private async searchBatch(
         batch: vscode.Uri[],
-        queryLower: string
+        searchPattern: SearchPattern
     ): Promise<Array<{ filePath: string; matches: SearchMatch[] } | null>> {
         return Promise.all(batch.map(async (file) => {
             try {
@@ -164,13 +169,8 @@ export class SearchService {
 
                 const uint8Array = await vscode.workspace.fs.readFile(file);
                 const text = new TextDecoder('utf-8', { fatal: false }).decode(uint8Array);
-                const textLower = text.toLowerCase();
 
-                if (!textLower.includes(queryLower)) {
-                    return null;
-                }
-
-                const matches = this.findMatchesInFile(file, text, textLower, queryLower);
+                const matches = this.findMatchesInFile(file, text, searchPattern);
                 return matches.length > 0 ? { filePath: file.fsPath, matches } : null;
             } catch (error) {
                 return null;
@@ -181,19 +181,16 @@ export class SearchService {
     private findMatchesInFile(
         file: vscode.Uri,
         text: string,
-        textLower: string,
-        queryLower: string
+        searchPattern: SearchPattern
     ): SearchMatch[] {
         const regularLines = text.split('\n');
-        const lowerLines = textLower.split('\n');
         const matches: SearchMatch[] = [];
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(file);
         const relativePath = workspaceFolder
             ? vscode.workspace.asRelativePath(file, false)
             : file.fsPath;
 
-        const matchExp = new RegExp(escapeRegExp(queryLower), 'g');
-        for (let i = 0; i < lowerLines.length; i++) {
+        for (let i = 0; i < regularLines.length; i++) {
             if (this.options.maxMatchesPerFile && matches.length >= this.options.maxMatchesPerFile) {
                 break;
             }
@@ -201,12 +198,11 @@ export class SearchService {
             const previewLine = regularLines[i];
             // const previewTrimOffset = regularLine.length - previewLine.length;
 
-            const lowerLine = lowerLines[i];
-            const lineMatches = lowerLine.matchAll(matchExp);
+            const lineMatches = findPatternMatches(previewLine, searchPattern);
             for (const match of lineMatches) {
                 // clamp line preview to max 50 characters before and after to prevent issues with extremely long lines
                 const start = Math.max(0, match.index - 50);
-                const end = Math.min(previewLine.length, match.index + queryLower.length + 50);
+                const end = Math.min(previewLine.length, match.index + match.length + 50);
                 const preview = previewLine.substring(start, end);
 
                 const trimmedPreview = preview.trimStart();
@@ -220,6 +216,7 @@ export class SearchService {
                     relativePath,
                     line: i + 1,
                     column: match.index,
+                    matchLength: match.length,
                     preview: trimmedPreview.trimEnd(),
                     previewColumn
                 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface SearchMatch {
     relativePath: string;
     line: number;
     column: number;
+    matchLength: number;
     previewColumn: number;
     preview: string;
 }
@@ -41,6 +42,7 @@ export type WebviewMessage = {
     text: string;
     includePattern?: string;
     excludePattern?: string;
+    isRegex?: boolean;
 } | {
     command: 'getFileContent'
     filePath: string;

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -15,6 +15,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
     };
 
     const searchInput = document.getElementById('searchInput')!;
+    const regexToggleButton = document.getElementById('regexToggleButton')!;
     const filterToggleButton = document.getElementById('filterToggleButton')!;
     const filterContainer = document.getElementById('filterContainer') as HTMLElement;
     const fileMaskInput = document.getElementById('fileMaskInput') as HTMLInputElement;
@@ -32,9 +33,9 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
     let currentScope: string = 'project';
     let scopePath: string = '';
     let fileMask: string = '';
+    let isRegexSearch = false;
 
     let selectedMatchIndex = -1;
-    let currentQuery = '';
     let fileContentsCache: {
         [key: string]: {
             content: string;
@@ -141,7 +142,6 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
             includePattern = convertFileMaskToPattern(currentFileMask);
         }
 
-        currentQuery = searchText;
         clearTimeout(searchTimeout);
 
         // Use longer delay for short queries as they are more likely to change
@@ -151,12 +151,20 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
                 command: 'search',
                 text: searchText,
                 includePattern: includePattern,
-                excludePattern: undefined
+                excludePattern: undefined,
+                isRegex: isRegexSearch
             });
         }, timeoutDelay);
     }
 
     searchInput.addEventListener('input', () => {
+        performSearch();
+    });
+
+    regexToggleButton.addEventListener('click', () => {
+        isRegexSearch = !isRegexSearch;
+        regexToggleButton.classList.toggle('active', isRegexSearch);
+        regexToggleButton.setAttribute('aria-pressed', String(isRegexSearch));
         performSearch();
     });
 
@@ -254,6 +262,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
                     relativePath: result.relativePath,
                     line: match.line,
                     column: match.column,
+                    matchLength: match.matchLength,
                     preview: match.preview,
                     previewColumn: match.previewColumn,
                     icon: result.icon
@@ -279,6 +288,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
                     relativePath: result.relativePath,
                     line: match.line,
                     column: match.column,
+                    matchLength: match.matchLength,
                     preview: match.preview,
                     previewColumn: match.previewColumn,
                     icon: result.icon
@@ -345,7 +355,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
                     <span class="file-name">${escapeHtml(fileName)}</span>
                 </div>`;
             }
-            const highlighted = highlightText(match.preview, currentQuery, match.previewColumn);
+            const highlighted = highlightText(match.preview, match.previewColumn, match.matchLength);
             html += `<div class="match-item" data-match-id="${match.matchId}" onclick="selectMatchById(${match.matchId})" ondblclick="openMatchById(${match.matchId}, event)">
                 <span class="match-line-number">[${match.line}]</span>
                 <span class="match-text">${highlighted}</span>
@@ -366,17 +376,15 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         return textEscaper.innerHTML;
     }
 
-    function highlightText(text: string, query: string, column: number): string {
-        if (!query) return escapeHtml(text);
-
+    function highlightText(text: string, column: number, matchLength: number): string {
         const escapedText = escapeHtml(text);
-        const index = text.toLowerCase().indexOf(query.toLowerCase(), column);
+        const index = column;
 
-        if (index === -1) return escapedText;
+        if (index < 0 || matchLength <= 0) return escapedText;
 
         const before = escapeHtml(text.substring(0, index));
-        const match = escapeHtml(text.substring(index, index + query.length));
-        const after = escapeHtml(text.substring(index + query.length));
+        const match = escapeHtml(text.substring(index, index + matchLength));
+        const after = escapeHtml(text.substring(index + matchLength));
 
         return `${before}<span class="match-highlight">${match}</span>${after}`;
     }
@@ -405,7 +413,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
                 filePath: match.filePath
             });
         } else {
-            displayFilePreview(match.filePath, match.line, match.column);
+            displayFilePreview(match.filePath, match.line, match.column, match.matchLength);
         }
     };
     // Make available globally for onclick handlers
@@ -460,7 +468,12 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         };
 
         if (selectedMatchIndex >= 0 && allMatches[selectedMatchIndex].filePath === filePath) {
-            displayFilePreview(filePath, allMatches[selectedMatchIndex].line, allMatches[selectedMatchIndex].column);
+            displayFilePreview(
+                filePath,
+                allMatches[selectedMatchIndex].line,
+                allMatches[selectedMatchIndex].column,
+                allMatches[selectedMatchIndex].matchLength
+            );
         }
     }
 
@@ -501,7 +514,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         performSearch();
     }
 
-    function displayFilePreview(filePath: string, lineNumber: number, columnNumber: number) {
+    function displayFilePreview(filePath: string, lineNumber: number, columnNumber: number, matchLength: number) {
         const cached = fileContentsCache[filePath];
         if (!cached) return;
 
@@ -523,12 +536,12 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
 
                 // Add search query highlighting on top of syntax highlighting
                 if (isMatchLine) {
-                    lineContent = addSearchHighlightToColorizedLine(lineContent, lines[i], currentQuery, columnNumber);
+                    lineContent = addSearchHighlightToColorizedLine(lineContent, columnNumber, matchLength);
                 }
             } else {
                 // Fallback to plain highlighting
                 if (isMatchLine) {
-                    lineContent = highlightSearchQuery(lines[i], currentQuery, columnNumber);
+                    lineContent = highlightSearchQuery(lines[i], columnNumber, matchLength);
                 } else {
                     lineContent = lines[i].replace(/</g, '&lt;').replace(/>/g, '&gt;');
                 }
@@ -584,42 +597,37 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         }
     }
 
-    function highlightSearchQuery(text: string, query: string, columnNumber: number): string {
-        if (!query) {
+    function highlightSearchQuery(text: string, columnNumber: number, matchLength: number): string {
+        if (matchLength <= 0) {
             return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
         }
 
-        const index = text.toLowerCase().indexOf(query.toLowerCase(), columnNumber);
+        const index = columnNumber;
         if (index === -1) {
             return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
         }
 
         const before = text.substring(0, index).replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        const match = text.substring(index, index + query.length).replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        const after = text.substring(index + query.length).replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const match = text.substring(index, index + matchLength).replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const after = text.substring(index + matchLength).replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
         return `${before}<span class="match-highlight">${match}</span>${after}`;
     }
 
-    function addSearchHighlightToColorizedLine(colorizedHtml: string, plainText: string, query: string, columnNumber: number): string {
-        if (!query) return colorizedHtml;
-
-        const index = plainText.toLowerCase().indexOf(query.toLowerCase());
-        if (index === -1) return colorizedHtml;
-
+    function addSearchHighlightToColorizedLine(colorizedHtml: string, columnNumber: number, matchLength: number): string {
         // Create a temporary div to work with the HTML
         const temp = document.createElement('div');
         temp.innerHTML = colorizedHtml;
 
         // Get the text content and find the position
         const textContent = temp.textContent || '';
-        const matchIndex = textContent.toLowerCase().indexOf(query.toLowerCase(), columnNumber);
+        const matchIndex = columnNumber;
 
-        if (matchIndex === -1) return colorizedHtml;
+        if (matchIndex < 0 || matchIndex >= textContent.length || matchLength <= 0) return colorizedHtml;
 
         // Walk through the nodes and wrap the matching text
         let currentPos = 0;
-        const matchEnd = matchIndex + query.length;
+        const matchEnd = matchIndex + matchLength;
 
         function wrapTextNodes(node: Node) {
             if (node.nodeType === Node.TEXT_NODE) {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -53,6 +53,13 @@ export function getWebviewContent(options: WebviewContentOptions): string {
                 placeholder="Search everywhere..."
                 autofocus
             />
+            <button
+                class="regex-toggle-button"
+                id="regexToggleButton"
+                title="Use regular expression"
+                aria-label="Use regular expression"
+                aria-pressed="false"
+            >.*</button>
             <button class="filter-toggle-button" id="filterToggleButton" title="Toggle file mask filter">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M1 2h14v2l-5 5v5l-4-2V9L1 4V2z"/>

--- a/tests/searchPattern.test.js
+++ b/tests/searchPattern.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert/strict');
+const { createSearchPattern, findPatternMatches } = require('../out/searchPattern');
+
+function collectMatches(text, query, isRegex) {
+  const pattern = createSearchPattern(query, isRegex);
+  return findPatternMatches(text, pattern).map((match) => ({
+    index: match.index,
+    length: match.length,
+  }));
+}
+
+assert.deepEqual(
+  collectMatches('Hello hello', 'hello', false),
+  [
+    { index: 0, length: 5 },
+    { index: 6, length: 5 },
+  ],
+  'literal search remains case-insensitive'
+);
+
+assert.deepEqual(
+  collectMatches('foo1 foo22 foo', 'foo\\d+', true),
+  [
+    { index: 0, length: 4 },
+    { index: 5, length: 5 },
+  ],
+  'regex search matches dynamic patterns'
+);
+
+assert.deepEqual(
+  collectMatches('foo.* foo42', 'foo.*', false),
+  [
+    { index: 0, length: 5 },
+  ],
+  'literal search escapes regex metacharacters'
+);
+
+assert.equal(
+  createSearchPattern('[', true),
+  null,
+  'invalid regex input is treated as an unsearchable pattern'
+);
+
+assert.deepEqual(
+  collectMatches('abc', '^', true),
+  [],
+  'zero-length regex matches are ignored to avoid infinite result loops'
+);
+
+console.log('searchPattern tests passed');

--- a/tests/searchPattern.test.js
+++ b/tests/searchPattern.test.js
@@ -47,4 +47,22 @@ assert.deepEqual(
   'zero-length regex matches are ignored to avoid infinite result loops'
 );
 
+const reusablePattern = createSearchPattern('foo', true);
+assert.equal(
+  reusablePattern.expression,
+  undefined,
+  'search patterns do not expose shared mutable RegExp state'
+);
+assert.deepEqual(
+  findPatternMatches('foo foo', reusablePattern).map((match) => ({
+    index: match.index,
+    length: match.length,
+  })),
+  [
+    { index: 0, length: 3 },
+    { index: 4, length: 3 },
+  ],
+  'reusable search patterns still find every match'
+);
+
 console.log('searchPattern tests passed');


### PR DESCRIPTION
Fixes #11.

## Summary
- Adds a `.*` regex toggle beside the search input.
- Sends regex mode through the webview search message and runs regex-aware matching in `SearchService`.
- Carries actual match length into result/preview rendering so regex matches are highlighted correctly.
- Adds a small pure matcher test for literal, regex, invalid regex, and zero-length patterns.

## Validation
- `npm run test:search-pattern`
- `git diff --check`

Note: `npm run lint` still fails because the repository has no ESLint configuration file for the existing lint script.