### PR TITLE
Remember search settings between reopenings

### DIFF
--- a/src/WebviewManager.ts
+++ b/src/WebviewManager.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { WebviewMessage } from './types';
+import { SearchState, WebviewMessage } from './types';
 import { SearchService } from './services/SearchService';
 import { FileService } from './services/FileService';
 import { SyntaxHighlightService } from './services/SyntaxHighlightService';
@@ -16,6 +16,7 @@ export class WebviewManager {
     private syntaxHighlightService: SyntaxHighlightService;
     private disposables: vscode.Disposable[] = [];
     private panelCounter: number = 0;
+    private lastSearchState: SearchState | undefined;
 
     constructor(private context: vscode.ExtensionContext) {
         this.searchService = new SearchService();
@@ -37,7 +38,7 @@ export class WebviewManager {
             return;
         }
 
-        this.createPanel();
+        this.createPanel(true);
     }
 
     showNewTab(initialSearchText?: string): void {
@@ -80,7 +81,7 @@ export class WebviewManager {
         this.syntaxHighlightService.dispose();
     }
 
-    private createPanel(): string {
+    private createPanel(restoreLastState: boolean = false): string {
         this.panelCounter++;
         const panelId = `search-${this.panelCounter}`;
         const tabNumber = this.panels.size + 1;
@@ -129,6 +130,16 @@ export class WebviewManager {
         });
         this.setupMessageHandler(panelId, panel);
         this.setupPanelDisposal(panelId, panel);
+
+        if (restoreLastState && this.lastSearchState) {
+            setTimeout(() => {
+                panel.webview.postMessage({
+                    command: 'restoreSearchState',
+                    state: this.lastSearchState
+                });
+            }, 100);
+        }
+
         return panelId;
     }
 
@@ -154,6 +165,10 @@ export class WebviewManager {
                 if (message.text) {
                     await this.handleSearch(panelId, panel, message.text, message.includePattern, message.excludePattern);
                 }
+                break;
+
+            case 'updateSearchState':
+                this.lastSearchState = message.state;
                 break;
 
             case 'getFileContent':

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,8 +44,12 @@ export function activate(context: vscode.ExtensionContext): void {
                 }
             }
 
-            // Fallback: open normal search tab (potentially with selected text)
-            webviewManager?.showNewTab(selectedText);
+            // Fallback: selected text starts a fresh search; otherwise return to the last search.
+            if (selectedText) {
+                webviewManager?.showNewTab(selectedText);
+            } else {
+                webviewManager?.show();
+            }
         }
     );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,11 +36,21 @@ export interface FileSearchResult {
     icon?: ResolvedIconDefinition;
 }
 
+export interface SearchState {
+    text: string;
+    fileMask: string;
+    scope: 'project' | 'directory';
+    scopePath: string;
+}
+
 export type WebviewMessage = {
     command: 'search'
     text: string;
     includePattern?: string;
     excludePattern?: string;
+} | {
+    command: 'updateSearchState'
+    state: SearchState;
 } | {
     command: 'getFileContent'
     filePath: string;

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -42,6 +42,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         }
     } = {};
     let searchTimeout: any = null;
+    let persistSearchStateTimeout: any = null;
 
     window.addEventListener('message', (event) => {
         const message = event.data;
@@ -86,10 +87,26 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
     }
 
     function persistSearchState() {
+        if (persistSearchStateTimeout) {
+            clearTimeout(persistSearchStateTimeout);
+            persistSearchStateTimeout = null;
+        }
+
         postMessage({
             command: 'updateSearchState',
             state: getSearchState()
         });
+    }
+
+    function schedulePersistSearchState() {
+        if (persistSearchStateTimeout) {
+            clearTimeout(persistSearchStateTimeout);
+        }
+
+        persistSearchStateTimeout = setTimeout(() => {
+            persistSearchStateTimeout = null;
+            persistSearchState();
+        }, 250);
     }
 
     /**
@@ -124,7 +141,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
 
     function performSearch() {
         const searchText = (searchInput as HTMLInputElement).value.trim();
-        persistSearchState();
+        schedulePersistSearchState();
 
         if (!searchText) {
             clearResults();

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 
-import { FileSearchResult, SearchMatch, WebviewMessage } from "../types";
+import { FileSearchResult, SearchMatch, SearchState, WebviewMessage } from "../types";
 
 
 type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResult['icon'] };
@@ -70,8 +70,27 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
             case 'setInitialSearchText':
                 handleSetInitialSearchText(message.text);
                 break;
+            case 'restoreSearchState':
+                handleRestoreSearchState(message.state);
+                break;
         }
     });
+
+    function getSearchState(): SearchState {
+        return {
+            text: (searchInput as HTMLInputElement).value.trim(),
+            fileMask,
+            scope: currentScope === 'directory' ? 'directory' : 'project',
+            scopePath
+        };
+    }
+
+    function persistSearchState() {
+        postMessage({
+            command: 'updateSearchState',
+            state: getSearchState()
+        });
+    }
 
     /**
      * Converts directory paths to glob patterns for file filtering.
@@ -105,6 +124,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
 
     function performSearch() {
         const searchText = (searchInput as HTMLInputElement).value.trim();
+        persistSearchState();
 
         if (!searchText) {
             clearResults();
@@ -174,6 +194,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
             filterToggleButton.classList.add('active');
             fileMaskInput.focus();
         }
+        persistSearchState();
     });
 
     fileMaskInput.addEventListener('input', () => {
@@ -476,18 +497,27 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         performSearch();
     }
 
+    function applyScope(scope: string) {
+        scopeButtons.forEach(btn => {
+            btn.classList.toggle('active', btn.getAttribute('data-scope') === scope);
+        });
+
+        currentScope = scope === 'directory' ? 'directory' : 'project';
+
+        if (currentScope === 'directory') {
+            scopeInputContainer.style.display = 'flex';
+        } else {
+            scopeInputContainer.style.display = 'none';
+            scopePath = '';
+            scopePathInput.value = '';
+        }
+    }
+
     function handleSetInitialDirectory(path: string, searchText?: string) {
         // Switch to directory scope
-        scopeButtons.forEach(btn => btn.classList.remove('active'));
-        const directoryButton = document.querySelector('[data-scope="directory"]');
-        if (directoryButton) {
-            directoryButton.classList.add('active');
-        }
-
-        currentScope = 'directory';
+        applyScope('directory');
         scopePath = path;
         scopePathInput.value = path;
-        scopeInputContainer.style.display = 'flex';
 
         // Set initial search text if provided
         if (searchText) {
@@ -498,6 +528,23 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
 
     function handleSetInitialSearchText(text: string) {
         (searchInput as HTMLInputElement).value = text;
+        performSearch();
+    }
+
+    function handleRestoreSearchState(state: SearchState) {
+        (searchInput as HTMLInputElement).value = state.text;
+
+        fileMask = state.fileMask;
+        fileMaskInput.value = state.fileMask;
+        filterContainer.style.display = state.fileMask ? 'flex' : 'none';
+        filterToggleButton.classList.toggle('active', Boolean(state.fileMask));
+
+        applyScope(state.scope);
+        if (state.scope === 'directory') {
+            scopePath = state.scopePath;
+            scopePathInput.value = state.scopePath;
+        }
+
         performSearch();
     }
 


### PR DESCRIPTION
Fixes #31.

## Summary
- Stores the latest search text, file mask, scope, and directory path while the webview is used.
- Restores those settings when reopening the normal search panel after a result was opened and the panel closed.
- Keeps selected-text searches and folder context-menu searches as explicit fresh searches.

## Validation
- `npm run compile`
- `git diff --check`

Note: `npm run lint` still fails because the repository has no ESLint configuration file for the existing lint script.