### PR TITLE
Fix preview loading for JSONC themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
+    "test:theme-loader": "npm run compile && node tests/themeLoader.test.js",
     "lint": "eslint src --ext ts"
   },
   "devDependencies": {

--- a/src/services/SyntaxHighlightService.ts
+++ b/src/services/SyntaxHighlightService.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { createHighlighter, Highlighter, BundledLanguage } from 'shiki';
 import path from 'path';
+import { loadThemeFile } from '../themeLoader';
 
 
 type TokenColor = {
@@ -43,7 +44,7 @@ export function getTheme(themeName: string | undefined): Theme | null {
     while (themePaths.length > 0) {
         const themePath = themePaths.pop();
         if (!themePath) throw new Error("this is to make typescript happy");
-        const theme: any = require(themePath);
+        const theme: any = loadThemeFile(themePath);
         if (theme) {
             if (theme.include) {
                 themePaths.push(path.join(path.dirname(themePath), theme.include));

--- a/src/themeLoader.ts
+++ b/src/themeLoader.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+
+export function stripJsonComments(json: string): string {
+    let result = '';
+    let inString = false;
+    let isEscaped = false;
+
+    for (let i = 0; i < json.length; i++) {
+        const current = json[i];
+        const next = json[i + 1];
+
+        if (inString) {
+            result += current;
+            if (isEscaped) {
+                isEscaped = false;
+            } else if (current === '\\') {
+                isEscaped = true;
+            } else if (current === '"') {
+                inString = false;
+            }
+            continue;
+        }
+
+        if (current === '"') {
+            inString = true;
+            result += current;
+            continue;
+        }
+
+        if (current === '/' && next === '/') {
+            while (i < json.length && json[i] !== '\n') {
+                i++;
+            }
+            result += '\n';
+            continue;
+        }
+
+        if (current === '/' && next === '*') {
+            i += 2;
+            while (i < json.length && !(json[i] === '*' && json[i + 1] === '/')) {
+                i++;
+            }
+            i++;
+            continue;
+        }
+
+        result += current;
+    }
+
+    return result;
+}
+
+export function removeTrailingCommas(json: string): string {
+    return json.replace(/,\s*([}\]])/g, '$1');
+}
+
+export function loadThemeFile(themePath: string): any {
+    try {
+        return require(themePath);
+    } catch {
+        const themeContent = fs.readFileSync(themePath, 'utf8');
+        return JSON.parse(removeTrailingCommas(stripJsonComments(themeContent)));
+    }
+}

--- a/tests/themeLoader.test.js
+++ b/tests/themeLoader.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { loadThemeFile } = require('../out/themeLoader');
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'storm-search-theme-'));
+const themePath = path.join(dir, 'theme.jsonc');
+fs.writeFileSync(themePath, `{
+  // JSONC comments are valid in VS Code theme files.
+  "name": "Commented Theme",
+  "colors": {
+    "editor.foreground": "#eeeeee",
+    "editor.background": "#101010",
+  },
+  "tokenColors": [
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#ff00ff",
+      },
+    },
+  ],
+}`);
+
+const theme = loadThemeFile(themePath);
+
+assert.equal(theme.name, 'Commented Theme');
+assert.equal(theme.colors['editor.foreground'], '#eeeeee');
+assert.equal(theme.tokenColors[0].settings.foreground, '#ff00ff');
+
+fs.rmSync(dir, { recursive: true, force: true });
+console.log('themeLoader tests passed');


### PR DESCRIPTION
Fixes #32.

## Summary
- Adds a resilient theme-file loader that can parse VS Code JSONC theme files with comments and trailing commas.
- Uses the loader when resolving the active VS Code color theme for Shiki preview highlighting.
- Adds a focused regression test for JSONC theme loading.

## Validation
- `npm run test:theme-loader`
- `git diff --check`

Note: `npm run lint` still fails because the repository has no ESLint configuration file for the existing lint script.