### PR TITLE
Add webview font fallbacks

### DIFF
--- a/media/styles.css
+++ b/media/styles.css
@@ -5,7 +5,7 @@
 }
 
 body {
-    font-family: var(--vscode-font-family);
+    font-family: var(--vscode-font-family), sans-serif;
     background: var(--vscode-editor-background);
     color: var(--vscode-editor-foreground);
     height: 100vh;
@@ -35,7 +35,7 @@ body {
     color: var(--vscode-input-foreground);
     font-size: 13px;
     padding: 6px 10px;
-    font-family: var(--vscode-font-family);
+    font-family: var(--vscode-font-family), sans-serif;
 }
 
 .search-input:focus {
@@ -90,7 +90,7 @@ body {
     color: var(--vscode-input-foreground);
     font-size: 12px;
     padding: 4px 8px;
-    font-family: var(--vscode-font-family);
+    font-family: var(--vscode-font-family), sans-serif;
 }
 
 .file-mask-input:focus {
@@ -122,7 +122,7 @@ body {
     border: none;
     padding: 4px 12px;
     font-size: 12px;
-    font-family: var(--vscode-font-family);
+    font-family: var(--vscode-font-family), sans-serif;
     cursor: pointer;
     border-right: 1px solid var(--vscode-input-border);
     transition: background 0.1s;
@@ -157,7 +157,7 @@ body {
     color: var(--vscode-input-foreground);
     font-size: 12px;
     padding: 4px 8px;
-    font-family: var(--vscode-font-family);
+    font-family: var(--vscode-font-family), sans-serif;
 }
 
 .scope-path-input:focus {
@@ -171,7 +171,7 @@ body {
     border-radius: 3px;
     padding: 4px 10px;
     font-size: 13px;
-    font-family: var(--vscode-font-family);
+    font-family: var(--vscode-font-family), sans-serif;
     cursor: pointer;
     font-weight: bold;
 }
@@ -267,7 +267,7 @@ body {
 }
 
 .match-text {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--vscode-editor-font-family), var(--vscode-font-family), monospace;
     font-size: 12px;
     overflow-wrap: break-word;
 }
@@ -311,7 +311,7 @@ body {
     color: var(--vscode-editorLineNumber-foreground);
     background: var(--vscode-editor-background);
     user-select: none;
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--vscode-editor-font-family), var(--vscode-font-family), monospace;
     font-size: 13px;
     line-height: 1.6;
     border-right: 1px solid var(--vscode-panel-border);
@@ -339,7 +339,7 @@ body.wrap-lines .preview-code-block {
 }
 
 .preview-code-block code {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--vscode-editor-font-family), var(--vscode-font-family), monospace;
     font-size: 13px;
     line-height: 1.6;
     background: transparent !important;


### PR DESCRIPTION
Fixes #33.

## Summary
- Adds explicit sans-serif fallbacks for UI text that uses the VS Code UI font variable.
- Adds editor/UI/monospace fallback chains for search result and preview code text.
- Prevents the webview from falling back to browser serif defaults when a configured VS Code font is unavailable.

## Validation
- `npm run compile`
- `git diff --check`

Note: `npm run lint` still fails because the repository has no ESLint configuration file for the existing lint script.