### PR TITLE
fix: align search results with theme colors

### DIFF
--- a/media/styles.css
+++ b/media/styles.css
@@ -4,6 +4,16 @@
     box-sizing: border-box;
 }
 
+:root {
+    --storm-search-results-background: var(--vscode-sideBar-background, var(--vscode-editorWidget-background, var(--vscode-input-background, var(--vscode-editor-background)));
+    --storm-search-results-foreground: var(--vscode-sideBar-foreground, var(--vscode-foreground));
+    --storm-search-results-header-background: var(--vscode-sideBarSectionHeader-background, var(--storm-search-results-background));
+    --storm-search-results-header-foreground: var(--vscode-sideBarSectionHeader-foreground, var(--vscode-descriptionForeground));
+    --storm-search-list-selection-background: var(--vscode-list-activeSelectionBackground, var(--vscode-list-inactiveSelectionBackground, transparent));
+    --storm-search-list-selection-foreground: var(--vscode-list-activeSelectionForeground, var(--vscode-list-inactiveSelectionForeground, var(--storm-search-results-foreground)));
+    --storm-search-list-highlight-foreground: var(--vscode-list-highlightForeground, var(--vscode-editor-foreground));
+}
+
 body {
     font-family: var(--vscode-font-family);
     background: var(--vscode-editor-background);
@@ -16,7 +26,7 @@ body {
 
 .search-header {
     padding: 12px 16px;
-    background: var(--vscode-sideBar-background);
+    background: var(--storm-search-results-background);
     border-bottom: 1px solid var(--vscode-panel-border);
 }
 
@@ -188,7 +198,8 @@ body {
 
 .results-panel {
     width: 400px;
-    background: var(--vscode-sideBar-background);
+    background: var(--storm-search-results-background);
+    color: var(--storm-search-results-foreground);
     border-right: 1px solid var(--vscode-panel-border);
     display: flex;
     flex-direction: column;
@@ -198,8 +209,8 @@ body {
 .results-header {
     padding: 8px 16px;
     font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    background: var(--vscode-sideBar-background);
+    color: var(--storm-search-results-header-foreground);
+    background: var(--storm-search-results-header-background);
     border-bottom: 1px solid var(--vscode-panel-border);
 }
 
@@ -215,8 +226,8 @@ body {
 .file-header {
     padding: 6px 16px;
     font-size: 12px;
-    color: var(--vscode-foreground);
-    background: var(--vscode-sideBar-background);
+    color: var(--storm-search-results-foreground);
+    background: var(--storm-search-results-background);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -245,6 +256,7 @@ body {
 .match-item {
     padding: 6px 16px 6px 38px;
     font-size: 12px;
+    color: var(--storm-search-results-foreground);
     cursor: pointer;
     border-left: 2px solid transparent;
 }
@@ -254,9 +266,9 @@ body {
 }
 
 .match-item.selected {
-    background: var(--vscode-list-activeSelectionBackground);
-    color: var(--vscode-list-activeSelectionForeground);
-    border-left-color: var(--vscode-list-activeSelectionForeground);
+    background: var(--storm-search-list-selection-background);
+    color: var(--storm-search-list-selection-foreground);
+    border-left-color: var(--vscode-focusBorder, var(--storm-search-list-selection-foreground));
 }
 
 .match-line-number {
@@ -272,9 +284,12 @@ body {
     overflow-wrap: break-word;
 }
 
-.match-highlight {
-    background: var(--vscode-editor-findMatchHighlightBackground);
-    color: var(--vscode-editor-foreground);
+.match-text .match-highlight {
+    background: transparent;
+    color: var(--storm-search-list-highlight-foreground);
+    border: none;
+    padding: 0;
+    font-weight: 600;
 }
 
 .preview-panel {
@@ -377,7 +392,7 @@ body.wrap-lines .code-line {
     background: var(--vscode-editor-lineHighlightBackground);
 }
 
-.match-highlight {
+.preview-code-block .match-highlight {
     background: var(--vscode-editor-findMatchBackground) !important;
     border: 1px solid var(--vscode-editor-findMatchBorder);
     padding: 0 2px;


### PR DESCRIPTION
Fixes #38

## Summary
- Route the search results pane through sidebar/list theme variables with editor/input fallbacks.
- Use `list.highlightForeground` for search-result match highlights so the left results list behaves more like VS Code's native Search view.
- Keep editor find-match highlighting scoped to the preview code pane.

## Verification
- `git diff --check`
- `npm run compile`

Note: `npm run lint` cannot run in the current repository because ESLint does not find a configuration file.