### PR TITLE
Expose navigation commands for keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - Start typing anywhere to automatically focus the search box
 - Navigate and open files without touching the mouse
 
+**Command IDs for keybindings:**
+- `custom-search.focusSearchInput` - Focus and select the Storm Search input
+- `custom-search.focusSearchResults` - Focus the Storm Search results list
+- `custom-search.focusEditor` - Return focus to the active VS Code editor group
+
+Example `keybindings.json` entry:
+
+```json
+{
+  "key": "ctrl+alt+s",
+  "command": "custom-search.focusSearchInput"
+}
+```
+
 The search respects your VS Code `files.exclude` and `search.exclude` settings.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "storm-search",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "storm-search",
-      "version": "1.0.3",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "shiki": "^3.15.0"
@@ -20,7 +20,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "vscode": "^1.80.0"
+        "vscode": "^1.106.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,18 @@
       {
         "command": "custom-search.searchInFolder",
         "title": "Storm Search: Search in Folder"
+      },
+      {
+        "command": "custom-search.focusSearchInput",
+        "title": "Storm Search: Focus Search Input"
+      },
+      {
+        "command": "custom-search.focusSearchResults",
+        "title": "Storm Search: Focus Search Results"
+      },
+      {
+        "command": "custom-search.focusEditor",
+        "title": "Storm Search: Focus Editor"
       }
     ],
     "menus": {

--- a/src/WebviewManager.ts
+++ b/src/WebviewManager.ts
@@ -72,6 +72,21 @@ export class WebviewManager {
         }
     }
 
+    focusWebviewTarget(target: 'searchInput' | 'searchResults'): void {
+        const panel = Array.from(this.panels.values()).pop();
+        if (!panel) {
+            this.createPanel();
+            setTimeout(() => this.focusWebviewTarget(target), 100);
+            return;
+        }
+
+        panel.reveal();
+        panel.webview.postMessage({
+            command: 'focusTarget',
+            target
+        });
+    }
+
     dispose(): void {
         this.panels.forEach(panel => panel.dispose());
         this.panels.clear();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,35 @@ export function activate(context: vscode.ExtensionContext): void {
         }
     );
 
-    context.subscriptions.push(openSearchCommand, openNewSearchTabCommand, searchInFolderCommand);
+    const focusSearchInputCommand = vscode.commands.registerCommand(
+        'custom-search.focusSearchInput',
+        () => {
+            webviewManager?.focusWebviewTarget('searchInput');
+        }
+    );
+
+    const focusSearchResultsCommand = vscode.commands.registerCommand(
+        'custom-search.focusSearchResults',
+        () => {
+            webviewManager?.focusWebviewTarget('searchResults');
+        }
+    );
+
+    const focusEditorCommand = vscode.commands.registerCommand(
+        'custom-search.focusEditor',
+        async () => {
+            await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
+        }
+    );
+
+    context.subscriptions.push(
+        openSearchCommand,
+        openNewSearchTabCommand,
+        searchInFolderCommand,
+        focusSearchInputCommand,
+        focusSearchResultsCommand,
+        focusEditorCommand
+    );
 }
 
 export function deactivate(): void {

--- a/src/webview/script.ts
+++ b/src/webview/script.ts
@@ -70,8 +70,27 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
             case 'setInitialSearchText':
                 handleSetInitialSearchText(message.text);
                 break;
+            case 'focusTarget':
+                handleFocusTarget(message.target);
+                break;
         }
     });
+
+    function handleFocusTarget(target: string) {
+        if (target === 'searchInput') {
+            searchInput.focus();
+            (searchInput as HTMLInputElement).select();
+            return;
+        }
+
+        if (target === 'searchResults') {
+            resultsList.focus();
+
+            if (selectedMatchIndex < 0 && allMatches.length > 0) {
+                selectMatchById(0);
+            }
+        }
+    }
 
     /**
      * Converts directory paths to glob patterns for file filtering.
@@ -346,7 +365,7 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
                 </div>`;
             }
             const highlighted = highlightText(match.preview, currentQuery, match.previewColumn);
-            html += `<div class="match-item" data-match-id="${match.matchId}" onclick="selectMatchById(${match.matchId})" ondblclick="openMatchById(${match.matchId}, event)">
+            html += `<div class="match-item" data-match-id="${match.matchId}" tabindex="-1" onclick="selectMatchById(${match.matchId})" ondblclick="openMatchById(${match.matchId}, event)">
                 <span class="match-line-number">[${match.line}]</span>
                 <span class="match-text">${highlighted}</span>
             </div>`;
@@ -394,6 +413,9 @@ type SearchMatchWithId = SearchMatch & { matchId: number, icon?: FileSearchResul
         const selectedItem = document.querySelector(`[data-match-id="${matchId}"]`);
         if (selectedItem) {
             selectedItem.classList.add('selected');
+            if (document.activeElement === resultsList) {
+                (selectedItem as HTMLElement).focus();
+            }
             selectedItem.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }
 

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -90,7 +90,7 @@ export function getWebviewContent(options: WebviewContentOptions): string {
             <div class="results-header" id="resultsHeader">
                 No results
             </div>
-            <div class="results-list" id="resultsList">
+            <div class="results-list" id="resultsList" tabindex="0">
                 <div class="empty-state">Start typing to search...</div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add command IDs for focusing the Storm Search input, results list, and active editor
- route focus commands to the active Storm Search webview
- make result rows/list keyboard-focusable and document keybinding usage

Fixes #15

## Verification
- npm run compile
- git diff --check

Note: `npm run lint` is currently blocked because this repo does not include an ESLint config file.