### PR TITLE
Respect workspace .gitignore during search

### DIFF
--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -65,6 +65,10 @@ export class SearchService {
             if (excludePattern) {
                 toGlobParts(excludePattern).forEach(p => args.push('--glob', `!${p}`));
             }
+            workspaceFolders
+                .map(folder => path.join(folder.uri.fsPath, '.gitignore'))
+                .filter(gitignorePath => fs.existsSync(gitignorePath))
+                .forEach(gitignorePath => args.push('--ignore-file', gitignorePath));
 
             args.push('--', query, ...workspaceFolders.map(f => f.uri.fsPath));
 


### PR DESCRIPTION
## Summary\n- pass each workspace .gitignore to ripgrep with --ignore-file\n- prevents Storm Search from returning results from files ignored by the project\n\n## Verification\n- npm run compile\n\nFixes #35